### PR TITLE
fix: redirect new budget button to /budget (temporary solution)

### DIFF
--- a/pages/dashboard.vue
+++ b/pages/dashboard.vue
@@ -53,7 +53,7 @@
           <span class="text-neutral-900 dark:text-neutral-50 font-medium">Nouvelle transaction</span>
         </button>
 
-        <button @click="openBudgetModal"
+        <button @click="navigateTo('/budget')"
                 class="card hover:shadow-md transition-shadow flex flex-col items-center justify-center p-4 text-center">
           <div class="rounded-full bg-primary-100 dark:bg-primary-900/30 p-3 mb-3">
             <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-primary-600 dark:text-primary-400" fill="none"


### PR DESCRIPTION
Close #15 

This solution is not ideal !
The ideal solution can be to directly open NewBudgetModal (need a little refactor to extract modal from budget.vue to a new component)
@qldwin 